### PR TITLE
Trim GitHub Actions, tests, and/or hooks

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,6 +3,11 @@ name: "GitHub Pages"
 on:
   push:
     branches: main
+    # Skip changes that don’t affect the site
+    paths-ignore:
+      - "**.md"
+      - ".github/**"
+      - "test/**"
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Pages builds no longer trigger for changes limited to Markdown files, workflow configuration, or test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->